### PR TITLE
Add parse functions that accept an fs.FS

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,14 +5,14 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.16
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Test
         run: go test -v

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bluekeyes/templatetree
 
-go 1.11
+go 1.16


### PR DESCRIPTION
This is the minimal change to add support for the io/fs package and does not break the API (other than requiring Go 1.16)

Closes #2.