### PR TITLE
Implement a new public API

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,6 +13,6 @@
 // path relative to the directory. If parsing a slice of templatetree.File
 // structs, the Name field in the struct sets the template's name.
 //
-// To define functions or set other options on the templates, pass a non-nil
-// root template as the final argument to the Load* or Parse* functions.
+// To define functions or set other options on the templates, provide a non-nil
+// factory function.
 package templatetree

--- a/example_test.go
+++ b/example_test.go
@@ -9,32 +9,23 @@ import (
 )
 
 func Example() {
-	files := []*templatetree.File{
-		&templatetree.File{
-			Name: "base.tmpl",
-			Content: strings.TrimSpace(`
+	files := map[string]string{
+		"base.tmpl": strings.TrimSpace(`
 Header
 {{block "body" .}}Body{{end}}
 Footer
 `),
-		},
-		&templatetree.File{
-			Name: "a.tmpl",
-			Content: strings.TrimSpace(`
+		"a.tmpl": strings.TrimSpace(`
 {{/* templatetree:extends base.tmpl */}}
 {{define "body"}}Body A{{end}}
 `),
-		},
-		&templatetree.File{
-			Name: "b.tmpl",
-			Content: strings.TrimSpace(`
+		"b.tmpl": strings.TrimSpace(`
 {{/* templatetree:extends base.tmpl */}}
 {{define "body"}}Body B{{end}}
 `),
-		},
 	}
 
-	t, err := templatetree.ParseText(files, nil)
+	t, err := templatetree.ParseFiles(files, templatetree.TextFactory(nil))
 	if err != nil {
 		panic(err)
 	}

--- a/template.go
+++ b/template.go
@@ -1,0 +1,79 @@
+package templatetree
+
+import (
+	html "html/template"
+	"io"
+	text "text/template"
+	"text/template/parse"
+)
+
+// Template defines common methods implemented by both *text/template.Template
+// and *html/template.Template.
+type Template interface {
+	Name() string
+	Execute(w io.Writer, data interface{}) error
+	ExecuteTemplate(w io.Writer, name string, data interface{}) error
+}
+
+// template is an adapter interface for stdlib template types
+type template interface {
+	Unwrap() Template
+
+	Name() string
+	Tree() *parse.Tree
+	AddParseTree(name string, tree *parse.Tree) error
+	Templates() []template
+	Parse(text string) error
+}
+
+type textTemplate struct {
+	*text.Template
+}
+
+func (t textTemplate) Unwrap() Template  { return t.Template }
+func (t textTemplate) Tree() *parse.Tree { return t.Template.Tree }
+
+func (t textTemplate) AddParseTree(name string, tree *parse.Tree) error {
+	_, err := t.Template.AddParseTree(name, tree)
+	return err
+}
+
+func (t textTemplate) Templates() []template {
+	ts := t.Template.Templates()
+	tmpls := make([]template, len(ts))
+	for i, tmpl := range ts {
+		tmpls[i] = textTemplate{tmpl}
+	}
+	return tmpls
+}
+
+func (t textTemplate) Parse(text string) error {
+	_, err := t.Template.Parse(text)
+	return err
+}
+
+type htmlTemplate struct {
+	*html.Template
+}
+
+func (t htmlTemplate) Unwrap() Template  { return t.Template }
+func (t htmlTemplate) Tree() *parse.Tree { return t.Template.Tree }
+
+func (t htmlTemplate) AddParseTree(name string, tree *parse.Tree) error {
+	_, err := t.Template.AddParseTree(name, tree)
+	return err
+}
+
+func (t htmlTemplate) Templates() []template {
+	ts := t.Template.Templates()
+	tmpls := make([]template, len(ts))
+	for i, tmpl := range ts {
+		tmpls[i] = htmlTemplate{tmpl}
+	}
+	return tmpls
+}
+
+func (t htmlTemplate) Parse(text string) error {
+	_, err := t.Template.Parse(text)
+	return err
+}

--- a/templatetree.go
+++ b/templatetree.go
@@ -16,184 +16,75 @@ const (
 	// CommentTagExtends is the tag used in template comments to mark a
 	// template's parent.
 	CommentTagExtends = "templatetree:extends"
-
-	// DefaultRootTemplateName is the name of the root template when none is
-	// provided by the caller.
-	DefaultRootTemplateName = "[templatetree:root]"
 )
 
-// File is an unparsed template definition.
-type File struct {
-	// Name is the template name. Child templates use this in the extends tag
-	// and it identifies the template in ExecuteTemplate calls.
-	Name string
-
-	// Content is the unparsed template definition.
-	Content string
-}
-
-// LoadText recursively loads all text templates in dir with names matching
-// pattern, respecting inheritance. If the root template is nil, a new default
-// template is used. Templates are named as normalized paths relative to dir.
-func LoadText(dir, pattern string, root *text.Template) (TextTree, error) {
-	return ParseTextFS(os.DirFS(dir), pattern, root)
-}
-
-// ParseTextFS recursively parses all text templates in fsys with names
-// matching pattern, respecting inheritance. If the root template is nil, a new
-// default template is used. Templates are named by their paths in fsys.
-func ParseTextFS(fsys fs.FS, pattern string, root *text.Template) (TextTree, error) {
-	files, err := loadFiles(fsys, pattern)
-	if err != nil {
-		return nil, err
-	}
-	return ParseText(files, root)
-}
-
-// ParseText parses files into a TextTree, respecting inheritance. If the root
-// template is nil, a new default template is used.
-func ParseText(files []*File, root *text.Template) (TextTree, error) {
-	if root == nil {
-		root = text.New(DefaultRootTemplateName)
-	}
-
-	tree := make(TextTree)
-	return tree, parseAll(files, textTemplate{root}, func(name string, t template) {
-		tree[name] = t.(textTemplate).Template
-	})
-}
-
-// LoadHTML recursively loads all HTML templates in dir with names matching
-// pattern, respecting inheritance. If the root template is nil, a new default
-// template is used. Templates are named as normalized paths relative to dir.
-func LoadHTML(dir, pattern string, root *html.Template) (HTMLTree, error) {
-	return ParseHTMLFS(os.DirFS(dir), pattern, root)
-}
-
-// ParseHTMLFS recursively loads all HTML templates in fsys with names matching
-// pattern, respecting inheritance. If the root template is nil, a new default
-// template is used. Templates are named by their paths in fsys.
-func ParseHTMLFS(fsys fs.FS, pattern string, root *html.Template) (HTMLTree, error) {
-	files, err := loadFiles(fsys, pattern)
-	if err != nil {
-		return nil, err
-	}
-	return ParseHTML(files, root)
-}
-
-// ParseHTML parses files into a HTMLTree, respecting inheritance. If the root
-// template is nil, a new default template is used.
-func ParseHTML(files []*File, root *html.Template) (HTMLTree, error) {
-	if root == nil {
-		root = html.New(DefaultRootTemplateName)
-	}
-
-	tree := make(HTMLTree)
-	return tree, parseAll(files, htmlTemplate{root}, func(name string, t template) {
-		tree[name] = t.(htmlTemplate).Template
-	})
-}
-
-// TextTree is a hierarchy of text templates, mapping name to template.
-type TextTree map[string]*text.Template
+// Tree is a hierarchy of templates, mapping name to template. The concrete
+// type of the values is determined by the TemplateFactory used when parsing
+// and will be either *text/template.Template or *html/template.Template.
+type Tree map[string]Template
 
 // ExecuteTemplate renders the template with the given name. See the
 // text/template package for more details.
-func (tree TextTree) ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
+func (tree Tree) ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
 	if tmpl, ok := tree[name]; ok {
 		return tmpl.Execute(wr, data)
 	}
 	return fmt.Errorf("templatetree: no template %q", name)
 }
 
-// HTMLTree is a hierarchy of text templates, mapping name to template.
-type HTMLTree map[string]*html.Template
+// TemplateFactory creates new empty templates.
+type TemplateFactory interface {
+	newTemplate(name string) template
+}
 
-// ExecuteTemplate renders the template with the given name. See the
-// html/template package for more details.
-func (tree HTMLTree) ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
-	if tmpl, ok := tree[name]; ok {
-		return tmpl.Execute(wr, data)
+// TextFactory is a TemplateFactory that creates text templates. If nil, it
+// uses text/template.New to create templates.
+type TextFactory func(name string) *text.Template
+
+func (f TextFactory) newTemplate(name string) template {
+	if f == nil {
+		return textTemplate{text.New(name)}
 	}
-	return fmt.Errorf("templatetree: no template %q", name)
+	return textTemplate{f(name)}
 }
 
-// adapter for text/template and html/template
-type template interface {
-	Name() string
-	Clone() (template, error)
-	Parse(string) error
-}
+// HTMLFactory is a TemplateFactory that creates HTML templates. If nil, it
+// uses html/template.New to create templates.
+type HTMLFactory func(name string) *html.Template
 
-type textTemplate struct {
-	*text.Template
-}
-
-func (t textTemplate) Clone() (template, error) {
-	nt, err := t.Template.Clone()
-	return textTemplate{nt}, err
-}
-
-func (t textTemplate) Parse(content string) error {
-	_, err := t.Template.Parse(content)
-	return err
-}
-
-type htmlTemplate struct {
-	*html.Template
-}
-
-func (t htmlTemplate) Clone() (template, error) {
-	nt, err := t.Template.Clone()
-	return htmlTemplate{nt}, err
-}
-
-func (t htmlTemplate) Parse(content string) error {
-	_, err := t.Template.Parse(content)
-	return err
-}
-
-type node struct {
-	name     string
-	content  string
-	template template
-	parent   *node
-}
-
-func loadFiles(templates fs.FS, pattern string) ([]*File, error) {
-	var files []*File
-	walkFn := func(name string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-
-		match, err := path.Match(pattern, path.Base(name))
-		if err != nil {
-			return err
-		}
-		if match {
-			b, err := fs.ReadFile(templates, name)
-			if err != nil {
-				return err
-			}
-			files = append(files, &File{Name: name, Content: string(b)})
-		}
-		return nil
+func (f HTMLFactory) newTemplate(name string) template {
+	if f == nil {
+		return htmlTemplate{html.New(name)}
 	}
+	return htmlTemplate{f(name)}
+}
 
-	if err := fs.WalkDir(templates, ".", walkFn); err != nil {
+// Parse recursively loads all templates in dir with names matching pattern,
+// respecting inheritance. Templates are named by their paths relative to dir.
+func Parse(dir, pattern string, f TemplateFactory) (Tree, error) {
+	return ParseFS(os.DirFS(dir), pattern, f)
+}
+
+// ParseFS recursively parses all templates in fsys with names matching
+// pattern, respecting inheritance. Templates are named by their paths in fsys.
+func ParseFS(fsys fs.FS, pattern string, f TemplateFactory) (Tree, error) {
+	files, err := loadFiles(fsys, pattern)
+	if err != nil {
 		return nil, err
 	}
-	return files, nil
+	return ParseFiles(files, f)
 }
 
-func parseAll(files []*File, root template, register func(string, template)) error {
+// ParseFiles parses all templates in files, respecting inheritance. Templates
+// are named by their key in files, which maps name to content.
+func ParseFiles(files map[string]string, f TemplateFactory) (Tree, error) {
+	if f == nil {
+		return nil, fmt.Errorf("templatetree: factory must be non-nil")
+	}
+
 	nodes := make(map[string]*node)
-	for _, f := range files {
-		nodes[f.Name] = &node{name: f.Name, content: f.Content}
+	for name, f := range files {
+		nodes[name] = &node{name: name, content: f}
 	}
 
 	// create links between parents and children
@@ -203,12 +94,13 @@ func parseAll(files []*File, root template, register func(string, template)) err
 			if p, ok := nodes[parent]; ok {
 				n.parent = p
 			} else {
-				return fmt.Errorf("templatetree: template %q extends unknown template %s", n.name, parent)
+				return nil, fmt.Errorf("templatetree: template %q extends unknown template %s", n.name, parent)
 			}
 		}
 	}
 
 	// parse templates from the root nodes in/down
+	tree := make(Tree)
 	for {
 		n := findNext(nodes)
 		if n == nil {
@@ -216,21 +108,19 @@ func parseAll(files []*File, root template, register func(string, template)) err
 		}
 		delete(nodes, n.name)
 
-		base := root
+		t := f.newTemplate(n.name)
 		if n.parent != nil {
-			base = n.parent.template
+			if err := copyTemplates(t, n.parent.template); err != nil {
+				return nil, err
+			}
 		}
 
-		t, err := base.Clone()
-		if err != nil {
-			return err
-		}
 		if err := t.Parse(n.content); err != nil {
-			return formatParseError(n, t, err)
+			return nil, err
 		}
 
 		n.template = t
-		register(n.name, t)
+		tree[n.name] = t.Unwrap()
 	}
 
 	// check for cycles
@@ -239,9 +129,29 @@ func parseAll(files []*File, root template, register func(string, template)) err
 		for _, n := range nodes {
 			names = append(names, strconv.Quote(n.name))
 		}
-		return fmt.Errorf("templatetree: inheritance cycle in templates [%s]", strings.Join(names, ", "))
+		return nil, fmt.Errorf("templatetree: inheritance cycle in templates [%s]", strings.Join(names, ", "))
 	}
 
+	return tree, nil
+}
+
+type node struct {
+	name     string
+	content  string
+	template template
+	parent   *node
+}
+
+func copyTemplates(dst, src template) error {
+	for _, t := range src.Templates() {
+		name := t.Name()
+		if name == src.Name() {
+			name = dst.Name() // copy top-level template in src to top-level in dst
+		}
+		if err := dst.AddParseTree(name, t.Tree()); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -269,14 +179,32 @@ func parseHeader(content string) (parent string) {
 	return
 }
 
-// The current template API doesn't provide a way to change names, so try to
-// edit the error message so the correct name appears for users. This is dirty,
-// but is strictly for usability, not correctness.
-func formatParseError(n *node, t template, err error) error {
-	msg := err.Error()
-	old := "template: " + t.Name()
-	if strings.HasPrefix(msg, old) {
-		return fmt.Errorf("template: %s%s", n.name, strings.TrimPrefix(msg, old))
+func loadFiles(fsys fs.FS, pattern string) (map[string]string, error) {
+	files := make(map[string]string)
+	walkFn := func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		match, err := path.Match(pattern, path.Base(name))
+		if err != nil {
+			return err
+		}
+		if match {
+			b, err := fs.ReadFile(fsys, name)
+			if err != nil {
+				return err
+			}
+			files[name] = string(b)
+		}
+		return nil
 	}
-	return err
+
+	if err := fs.WalkDir(fsys, ".", walkFn); err != nil {
+		return nil, err
+	}
+	return files, nil
 }

--- a/templatetree_test.go
+++ b/templatetree_test.go
@@ -7,12 +7,13 @@ import (
 )
 
 func TestText(t *testing.T) {
-	root := text.New("root")
-	root.Funcs(text.FuncMap{
-		"Value": func() string { return "Test Value" },
+	factory := TextFactory(func(name string) *text.Template {
+		return text.New("root").Funcs(text.FuncMap{
+			"Value": func() string { return "Test Value" },
+		})
 	})
 
-	tmpl, err := LoadText("testdata/basic", "*.tmpl", root)
+	tmpl, err := Parse("testdata/basic", "*.tmpl", factory)
 	if err != nil {
 		t.Fatalf("error loading templates: %v", err)
 	}
@@ -47,7 +48,7 @@ func TestText(t *testing.T) {
 }
 
 func TestDetectCycles(t *testing.T) {
-	_, err := LoadText("testdata/cycles", "*.tmpl", nil)
+	_, err := Parse("testdata/cycles", "*.tmpl", TextFactory(nil))
 	if err == nil {
 		t.Fatal("template cycle was not detected")
 	}
@@ -64,7 +65,7 @@ func TestDetectCycles(t *testing.T) {
 	}
 }
 
-func render(tree TextTree, name string) (string, error) {
+func render(tree Tree, name string) (string, error) {
 	var b strings.Builder
 	if err := tree.ExecuteTemplate(&b, name, nil); err != nil {
 		return "", err
@@ -72,7 +73,7 @@ func render(tree TextTree, name string) (string, error) {
 	return b.String(), nil
 }
 
-func assertRender(t *testing.T, tree TextTree, name string) string {
+func assertRender(t *testing.T, tree Tree, name string) string {
 	out, err := render(tree, name)
 	if err != nil {
 		t.Fatalf("error rendering %q: %v", name, err)


### PR DESCRIPTION
Functionally, the package works the same way as before, but it defines a new interface that I think is easier to use:

* Remove most text/html function variants. There is now a single `Tree` type and single set of parse functions. Whether to use text or html is accomplished by providing a` TemplateFactory`.
* Remove `Load*` functions, all creation functions now start with `Parse`
* Allow full customization of templates with a factory function. Clients can customize each template, instead of only the root.
* Removed the `File` type in favor of `map[string]string`
* Internally, use `AddParseTree` instead of `Clone` to copy templates, which should resolve all issues with incorrect template names.

Because the API was small to being with, I expect that updating to the new API will be fast and straightforward.

Closes #1. (Templates have the correct names, eliminating the need for error mangling)
Closes #3. (No options, but everything the options would support is now supported)
Closes #5.