### PR TITLE
Fix rendering for HTML templates

### DIFF
--- a/template.go
+++ b/template.go
@@ -61,7 +61,7 @@ func (t htmlTemplate) Tree() *parse.Tree { return t.Template.Tree }
 
 func (t htmlTemplate) AddParseTree(name string, tree *parse.Tree) error {
 	_, err := t.Template.AddParseTree(name, tree)
-	if name == t.Name() && t.Template.Tree == nil {
+	if name == t.Name() {
 		// html/template (as of 1.16.6) has an issue where it does not set the
 		// Tree of the top-level template when the added tree replaces it.
 		//

--- a/template.go
+++ b/template.go
@@ -61,6 +61,14 @@ func (t htmlTemplate) Tree() *parse.Tree { return t.Template.Tree }
 
 func (t htmlTemplate) AddParseTree(name string, tree *parse.Tree) error {
 	_, err := t.Template.AddParseTree(name, tree)
+	if name == t.Name() && t.Template.Tree == nil {
+		// html/template (as of 1.16.6) has an issue where it does not set the
+		// Tree of the top-level template when the added tree replaces it.
+		//
+		// TODO(bkeyes): report this upstream and see if it's actually a bug,
+		// since AddParseTree is not _really_ meant for public use.
+		t.Template.Tree = tree
+	}
 	return err
 }
 

--- a/templatetree_test.go
+++ b/templatetree_test.go
@@ -1,6 +1,7 @@
 package templatetree
 
 import (
+	html "html/template"
 	"strings"
 	"testing"
 	text "text/template"
@@ -39,6 +40,32 @@ func TestText(t *testing.T) {
 	t.Run("nestedTemplate", func(t *testing.T) {
 		out := assertRender(t, tmpl, "nested/c.tmpl")
 		assertOutput(t, out, []string{"Base", "C", "Default"})
+	})
+
+	t.Run("multilevelInheritance", func(t *testing.T) {
+		out := assertRender(t, tmpl, "nested/d.tmpl")
+		assertOutput(t, out, []string{"Base", "D", "Test Value"})
+	})
+}
+
+func TestHTML(t *testing.T) {
+	factory := HTMLFactory(func(name string) *html.Template {
+		return html.New("root").Funcs(html.FuncMap{
+			"Value": func() string { return "Test Value" },
+		})
+	})
+
+	tmpl, err := Parse("testdata/basic", "*.tmpl", factory)
+	if err != nil {
+		t.Fatalf("error loading templates: %v", err)
+	}
+
+	t.Run("basicInheritance", func(t *testing.T) {
+		out := assertRender(t, tmpl, "a.tmpl")
+		assertOutput(t, out, []string{"Base", "A"})
+
+		out = assertRender(t, tmpl, "b.tmpl")
+		assertOutput(t, out, []string{"Base", "B"})
 	})
 
 	t.Run("multilevelInheritance", func(t *testing.T) {


### PR DESCRIPTION
I missed testing this because I assumed the text and html packages would
behave the same way. However, the html package has a bug in AddParseTree
that does the wrong thing when the new parse tree replaces the top-level
template.