### PR TITLE
Fix execution errors for HTML templates

### DIFF
--- a/template.go
+++ b/template.go
@@ -4,7 +4,6 @@ import (
 	html "html/template"
 	"io"
 	text "text/template"
-	"text/template/parse"
 )
 
 // Template defines common methods implemented by both *text/template.Template
@@ -18,11 +17,7 @@ type Template interface {
 // template is an adapter interface for stdlib template types
 type template interface {
 	Unwrap() Template
-
 	Name() string
-	Tree() *parse.Tree
-	AddParseTree(name string, tree *parse.Tree) error
-	Templates() []template
 	Parse(text string) error
 }
 
@@ -30,22 +25,7 @@ type textTemplate struct {
 	*text.Template
 }
 
-func (t textTemplate) Unwrap() Template  { return t.Template }
-func (t textTemplate) Tree() *parse.Tree { return t.Template.Tree }
-
-func (t textTemplate) AddParseTree(name string, tree *parse.Tree) error {
-	_, err := t.Template.AddParseTree(name, tree)
-	return err
-}
-
-func (t textTemplate) Templates() []template {
-	ts := t.Template.Templates()
-	tmpls := make([]template, len(ts))
-	for i, tmpl := range ts {
-		tmpls[i] = textTemplate{tmpl}
-	}
-	return tmpls
-}
+func (t textTemplate) Unwrap() Template { return t.Template }
 
 func (t textTemplate) Parse(text string) error {
 	_, err := t.Template.Parse(text)
@@ -56,30 +36,7 @@ type htmlTemplate struct {
 	*html.Template
 }
 
-func (t htmlTemplate) Unwrap() Template  { return t.Template }
-func (t htmlTemplate) Tree() *parse.Tree { return t.Template.Tree }
-
-func (t htmlTemplate) AddParseTree(name string, tree *parse.Tree) error {
-	_, err := t.Template.AddParseTree(name, tree)
-	if name == t.Name() {
-		// html/template (as of 1.16.6) has an issue where it does not set the
-		// Tree of the top-level template when the added tree replaces it.
-		//
-		// TODO(bkeyes): report this upstream and see if it's actually a bug,
-		// since AddParseTree is not _really_ meant for public use.
-		t.Template.Tree = tree
-	}
-	return err
-}
-
-func (t htmlTemplate) Templates() []template {
-	ts := t.Template.Templates()
-	tmpls := make([]template, len(ts))
-	for i, tmpl := range ts {
-		tmpls[i] = htmlTemplate{tmpl}
-	}
-	return tmpls
-}
+func (t htmlTemplate) Unwrap() Template { return t.Template }
 
 func (t htmlTemplate) Parse(text string) error {
 	_, err := t.Template.Parse(text)

--- a/testdata/html/data.html.tmpl
+++ b/testdata/html/data.html.tmpl
@@ -1,0 +1,3 @@
+{{/* templatetree:extends layout.html.tmpl */}}
+{{define "title"}}Data Page | {{.Word}}{{end}}
+{{define "body"}}<p>This contains the word <i>{{.Word}}</i></p>{{end}}

--- a/testdata/html/index.html.tmpl
+++ b/testdata/html/index.html.tmpl
@@ -1,0 +1,3 @@
+{{/* templatetree:extends layout.html.tmpl */}}
+{{define "title"}}Index Page{{end}}
+{{define "body"}}<p>This is a test page!</p>{{end}}

--- a/testdata/html/layout.html.tmpl
+++ b/testdata/html/layout.html.tmpl
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <head>
+        <title>{{block "title" .}}Page Layout{{end}}</title>
+    </head>
+    <body>
+        {{block "body" .}}{{end}}
+    </body>
+</html>


### PR DESCRIPTION
Using AddParseTree works correctly for text templates, but has a bug
that breaks all HTML templates (golang/go#48477). Attempting to
workaround that bug using the public interface appears to work at first,
but leads to even stranger errors rendering some templates.

While I wanted to avoid parsing templates multiple times, it resolves
all issues I've found so far and simplifies the code, so use it for now.
In most application, parsing templates should be a one-time cost anyway.

Also add some new unit tests for HTML templates that failed when using
the old logic.